### PR TITLE
Feat: Add markdown list and quote support

### DIFF
--- a/themes/Sourcerer-color-theme.json
+++ b/themes/Sourcerer-color-theme.json
@@ -242,6 +242,18 @@
 			}
 		},
 		{
+			"scope": "punctuation.definition.quote.begin.markdown",
+			"settings": {
+				"foreground": "#CC8800"
+			}
+		},
+		{
+			"scope": "punctuation.definition.list.begin.markdown",
+			"settings": {
+				"foreground": "#6688AA"
+			}
+		},
+		{
 			"name": "[VSCODE-CUSTOM] Markdown List Punctuation Definition",
 			"scope": "beginning.punctuation.definition.list.markdown",
 			"settings": {


### PR DESCRIPTION
Markdown was missing lists and quotes. Added support for them:

![preview](https://user-images.githubusercontent.com/2429731/47225568-3c3b0200-d373-11e8-8a9b-4c390a113083.png)
