### PR TITLE
Update peek highlight color to be readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@
 ### [v1.0.0]
 - Bump version as theme is stable
 - Correct theme name
+
+### [v1.0.5]
+- Fix peek highlight color unreadable bug

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "sourcerer",
     "displayName": "Sourcerer",
     "description": "Sourcerer Theme based on the Vim and Hyper themes",
-    "version": "1.0.4",
+    "version": "1.0.5",
     "publisher": "bpruitt-goddard",
     "license": "MIT",
     "engines": {

--- a/themes/Sourcerer-color-theme.json
+++ b/themes/Sourcerer-color-theme.json
@@ -17,6 +17,7 @@
 		"editorSuggestWidget.border": "#181818",
 		"editorSuggestWidget.selectedBackground": "#181818",
 		"editorWhitespace.foreground": "#3B3A32",
+		"peekViewEditor.matchHighlightBackground": "#464646",
 		"input.background": "#222222",
 		"list.activeSelectionBackground": "#222222",
 		"list.activeSelectionForeground": "#C2C2B0",


### PR DESCRIPTION
Fix for #4 

There was no color specified for the highlighted item, so it was a default value. Tested with `C` and `C#` languages. As the value is simply 10% lighter than the line background, it shouldn't run into any more unreadable issues🤞.

**Before fix:**
![before](https://user-images.githubusercontent.com/2429731/49885846-2125c500-fded-11e8-8c62-be390ec57d85.PNG)

**After fix:**
![after](https://user-images.githubusercontent.com/2429731/49885863-28e56980-fded-11e8-9343-007647d4c345.PNG)

